### PR TITLE
Fix CLI version fallback

### DIFF
--- a/backend/pyspur/cli/main.py
+++ b/backend/pyspur/cli/main.py
@@ -2,7 +2,7 @@
 
 import os
 import shutil
-from importlib.metadata import version as get_version
+from importlib.metadata import PackageNotFoundError, version as get_version
 from pathlib import Path
 from typing import Optional
 
@@ -28,7 +28,7 @@ def show_version() -> None:
     try:
         ver = get_version("pyspur")
         print(f"PySpur version: [bold green]{ver}[/bold green]")
-    except ImportError:
+    except (ImportError, PackageNotFoundError):
         print("[yellow]PySpur version: unknown (package not installed)[/yellow]")
 
 

--- a/backend/tests/cli/test_main.py
+++ b/backend/tests/cli/test_main.py
@@ -35,6 +35,16 @@ def test_version_command_import_error(runner: CliRunner) -> None:
         assert "unknown" in result.stdout
 
 
+def test_version_command_package_not_found(runner: CliRunner) -> None:
+    """Test the version command handles PackageNotFoundError gracefully."""
+    from importlib.metadata import PackageNotFoundError
+
+    with patch("pyspur.cli.main.get_version", side_effect=PackageNotFoundError()):
+        result: Result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert "unknown" in result.stdout
+
+
 @pytest.mark.parametrize(
     "sqlite_flag,expected_env_var",
     [


### PR DESCRIPTION
## Summary
- handle `PackageNotFoundError` in the CLI `version` command
- add regression test for the new error case

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_687a488a3bb8832f8edf6fbe916d203e